### PR TITLE
Clear cache only in EE (where oxCache exists).

### DIFF
--- a/copy_this/application/commands/cacheclearcommand.php
+++ b/copy_this/application/commands/cacheclearcommand.php
@@ -49,11 +49,14 @@ class CacheClearCommand extends oxConsoleCommand
     {
         $oInput = $this->getInput();
 
-        $oOutput->writeLn('Clearing OXID db and backend cache..');
-        /** @var oxCache $oCache */
-        $oCache = oxNew('oxcache');
-        $oCache->reset(false);
-        $oOutput->writeLn('Oxid Cache cleared successfully');
+        if (oxRegistry::getConfig()->getEdition() == 'EE')
+        {
+	        $oOutput->writeLn('Clearing OXID db and backend cache..');
+	        /** @var oxCache $oCache */
+	        $oCache = oxNew('oxcache');
+	        $oCache->reset(false);
+	        $oOutput->writeLn('Oxid Cache cleared successfully');
+        }
 
 
         $sTmpDir = $this->_appendDirectorySeparator(oxRegistry::getConfig()->getConfigParam('sCompileDir'));


### PR DESCRIPTION
Makes cache:clear compatible with CE and PE.
